### PR TITLE
fix_issue1

### DIFF
--- a/api/swift_api/views.py
+++ b/api/swift_api/views.py
@@ -264,8 +264,8 @@ def storage_policy_disks(request, storage_policy_id):
             object_node_id, device_id = disk.split(':')
             object_node = r.hgetall('object_node:' + object_node_id)
             # device_detail = json.loads(object_node['devices'])[device_id]
-            region = r.hgetall('region:' + object_node['region_id'])['name']
-            zone = r.hgetall('zone:' + object_node['zone_id'])['name']
+            region = object_node['region_id']
+            zone = object_node['zone_id']
 
             tmp_policy_file = get_policy_file_path(settings.SWIFT_CFG_TMP_DIR, storage_policy_id)
 

--- a/api/swift_api/views.py
+++ b/api/swift_api/views.py
@@ -270,7 +270,7 @@ def storage_policy_disks(request, storage_policy_id):
             tmp_policy_file = get_policy_file_path(settings.SWIFT_CFG_TMP_DIR, storage_policy_id)
 
             ring = RingBuilder.load(tmp_policy_file)
-            ring_dev_id = ring.add_dev({'weight': 100, 'region': region, 'zone': zone, 'ip': object_node['ip'], 'port': '6200', 'device': device_id})
+            ring_dev_id = ring.add_dev({'weight': 100, 'region': int(region), 'zone': int(zone), 'ip': object_node['ip'], 'port': 6200, 'device': device_id})
             ring.save(tmp_policy_file)
 
             storage_policy = r.hgetall(key)


### PR DESCRIPTION
造成[builder文件格式错误](https://github.com/OStorage/crystal-controller/issues/1)的原因是添加设备时，使用的region、zone和端口均为字符串类型。应为数值类型。